### PR TITLE
Add existingSecret support for all sensitive values

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,60 @@ This value is used as the secret for encryption
 * textualEncryptionSecret: Any string value is valid
 
 
+## Using Existing Kubernetes Secrets
+
+For all sensitive values, instead of providing the value directly in `values.yaml`, you can reference a pre-existing Kubernetes secret. This is useful when secrets are managed externally (e.g. synced from AWS Secrets Manager, Azure Key Vault, or HashiCorp Vault via a CSI driver).
+
+The pattern for each is an `ExistingSecret` field (the secret name) and an optional `ExistingSecretKey` field (the key within the secret, defaulting to the value shown below).
+
+### Database password
+
+```yaml
+textualDatabase:
+  # Option A: provide the password directly
+  password: <password>
+  # Option B: reference an existing secret
+  existingSecret: <secret-name>
+  existingSecretKey: password  # default
+```
+
+### Solar license
+
+```yaml
+# Option A: provide the license directly
+solarLicense: <license>
+# Option B: reference an existing secret
+solarLicenseExistingSecret: <secret-name>
+solarLicenseExistingSecretKey: secret  # default
+```
+
+### Encryption secret
+
+```yaml
+# Option A: provide the value directly
+textualEncryptionSecret: <value>
+# Option B: reference an existing secret
+textualEncryptionSecretExistingSecret: <secret-name>
+textualEncryptionSecretExistingSecretKey: secret  # default
+```
+
+### Optional secrets
+
+The same pattern applies to all other sensitive values:
+
+| Value | ExistingSecret field | ExistingSecretKey field | Default key |
+|---|---|---|---|
+| `openAiApiKey` | `openAiApiKeyExistingSecret` | `openAiApiKeyExistingSecretKey` | `secret` |
+| `chatApiKey` | `chatApiKeyExistingSecret` | `chatApiKeyExistingSecretKey` | `secret` |
+| `azureDocIntelligenceKey` | `azureDocIntelligenceKeyExistingSecret` | `azureDocIntelligenceKeyExistingSecretKey` | `secret` |
+| `googleClientSecret` | `googleClientSecretExistingSecret` | `googleClientSecretExistingSecretKey` | `secret` |
+| `githubClientSecret` | `githubClientSecretExistingSecret` | `githubClientSecretExistingSecretKey` | `secret` |
+| `azureClientSecret` | `azureClientSecretExistingSecret` | `azureClientSecretExistingSecretKey` | `secret` |
+| `keycloakClientSecret` | `keycloakClientSecretExistingSecret` | `keycloakClientSecretExistingSecretKey` | `secret` |
+
+When using an `ExistingSecret`, the chart will not create a Kubernetes secret for that value — it will reference the named secret directly. For optional values, if neither the direct value nor `ExistingSecret` is set, the corresponding environment variable is simply omitted.
+
+
 ### Authorization to access Tonic application Docker images
 
 Tonic hosts our application images on a private quay.io repository. Authorization is required to pull the images.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -218,3 +218,48 @@ Select the busybox image
 name: {{ .Values.textualDatabase.existingSecret | default "textual-db-password" }}
 key: {{ .Values.textualDatabase.existingSecretKey | default "password" }}
 {{- end }}
+
+{{- define "textual.licenseSecretRef" -}}
+name: {{ .Values.solarLicenseExistingSecret | default "solar-license-secret" }}
+key: {{ .Values.solarLicenseExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.encryptionSecretRef" -}}
+name: {{ .Values.textualEncryptionSecretExistingSecret | default "textual-encryption-secret" }}
+key: {{ .Values.textualEncryptionSecretExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.openAiApiKeySecretRef" -}}
+name: {{ .Values.openAiApiKeyExistingSecret | default "openai-api-key" }}
+key: {{ .Values.openAiApiKeyExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.chatApiKeySecretRef" -}}
+name: {{ .Values.chatApiKeyExistingSecret | default "chat-api-key" }}
+key: {{ .Values.chatApiKeyExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.googleClientSecretRef" -}}
+name: {{ .Values.googleClientSecretExistingSecret | default "google-sso-client-secret" }}
+key: {{ .Values.googleClientSecretExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.githubClientSecretRef" -}}
+name: {{ .Values.githubClientSecretExistingSecret | default "github-sso-client-secret" }}
+key: {{ .Values.githubClientSecretExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.azureClientSecretRef" -}}
+name: {{ .Values.azureClientSecretExistingSecret | default "azure-sso-client-secret" }}
+key: {{ .Values.azureClientSecretExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.keycloakClientSecretRef" -}}
+name: {{ .Values.keycloakClientSecretExistingSecret | default "keycloak-sso-client-secret" }}
+key: {{ .Values.keycloakClientSecretExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.azureDocIntelligenceKeySecretRef" -}}
+name: {{ .Values.azureDocIntelligenceKeyExistingSecret | default "azure-document-intelligence-key-secret" }}
+key: {{ .Values.azureDocIntelligenceKeyExistingSecretKey | default "secret" }}
+{{- end }}

--- a/templates/solar-api-server-deployment.yaml
+++ b/templates/solar-api-server-deployment.yaml
@@ -73,8 +73,7 @@ spec:
           - name: SOLAR_SECRET
             valueFrom:
               secretKeyRef:
-                name: textual-encryption-secret
-                key: secret
+                {{- include "textual.encryptionSecretRef" . | nindent 16 }}
           - name: SOLAR_DB_DATABASE
             value: {{ .Values.textualDatabase.dbName }}
           - name: SOLAR_DB_USERNAME
@@ -103,12 +102,11 @@ spec:
           - name: SOLAR_AUTH_RPM_LIMIT
             value: {{quote .Values.solarAuthRpmLimit }}
           {{- end }}
-          {{- if .Values.openAiApiKey }}
+          {{- if or .Values.openAiApiKey .Values.openAiApiKeyExistingSecret }}
           - name: OPENAI_API_KEY
             valueFrom:
               secretKeyRef:
-                name: openai-api-key
-                key: secret
+                {{- include "textual.openAiApiKeySecretRef" . | nindent 16 }}
           {{- end }}
           {{- if .Values.chatLlmProvider }}
           - name: CHAT_LLM_PROVIDER
@@ -122,23 +120,21 @@ spec:
           - name: CHAT_MODEL_NAME
             value: {{ .Values.chatModelName }}
           {{- end }}
-          {{- if .Values.chatApiKey }}
+          {{- if or .Values.chatApiKey .Values.chatApiKeyExistingSecret }}
           - name: CHAT_API_KEY
             valueFrom:
               secretKeyRef:
-                name: chat-api-key
-                key: secret
+                {{- include "textual.chatApiKeySecretRef" . | nindent 16 }}
           {{- end }}
           {{- if .Values.googleClientId }}
           - name: SOLAR_SSO_GOOGLE_CLIENT_ID
             value: {{ .Values.googleClientId }}
           {{- end }}
-          {{- if .Values.googleClientSecret }}
+          {{- if or .Values.googleClientSecret .Values.googleClientSecretExistingSecret }}
           - name: SOLAR_SSO_GOOGLE_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: google-sso-client-secret
-                key: secret
+                {{- include "textual.googleClientSecretRef" . | nindent 16 }}
           {{- end }}
           {{- if .Values.googleGroupFilterRegex }}
           - name: SOLAR_SSO_GOOGLE_GROUP_FILTER_REGEX
@@ -148,12 +144,11 @@ spec:
           - name: SOLAR_SSO_GITHUB_CLIENT_ID
             value: {{ .Values.githubClientId }}
           {{- end }}
-          {{- if .Values.githubClientSecret }}
+          {{- if or .Values.githubClientSecret .Values.githubClientSecretExistingSecret }}
           - name: SOLAR_SSO_GITHUB_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: github-sso-client-secret
-                key: secret
+                {{- include "textual.githubClientSecretRef" . | nindent 16 }}
           {{- end }}
           {{- if .Values.oktaClientId }}
           - name: SOLAR_SSO_OKTA_CLIENT_ID
@@ -183,12 +178,11 @@ spec:
           - name: SOLAR_SSO_AZURE_TENANT_ID
             value: {{ .Values.azureTenantId }}
           {{- end }}
-          {{- if .Values.azureClientSecret }}
+          {{- if or .Values.azureClientSecret .Values.azureClientSecretExistingSecret }}
           - name: SOLAR_SSO_AZURE_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: azure-sso-client-secret
-                key: secret
+                {{- include "textual.azureClientSecretRef" . | nindent 16 }}
           {{- end }}
           {{- if .Values.azureGroupFilterRegex }}
           - name: SOLAR_SSO_AZURE_GROUP_FILTER_REGEX
@@ -198,12 +192,11 @@ spec:
           - name: SOLAR_SSO_KEYCLOAK_CLIENT_ID
             value: {{ .Values.keycloakClientId }}
           {{- end }}
-          {{- if .Values.keycloakClientSecret }}
+          {{- if or .Values.keycloakClientSecret .Values.keycloakClientSecretExistingSecret }}
           - name: SOLAR_SSO_KEYCLOAK_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: keycloak-sso-client-secret
-                key: secret
+                {{- include "textual.keycloakClientSecretRef" . | nindent 16 }}
           {{- end }}
           {{- if .Values.keycloakAuthority }}
           - name: SOLAR_SSO_KEYCLOAK_AUTHORITY
@@ -266,8 +259,7 @@ spec:
           - name: SOLAR_LICENSE
             valueFrom:
               secretKeyRef:
-                name: solar-license-secret
-                key: secret
+                {{- include "textual.licenseSecretRef" . | nindent 16 }}
           {{- if  (.Values.textual_api_server).image }}
           image: {{ .Values.textual_api_server.image }}:{{ .Values.textualVersion }}
           {{ else }}

--- a/templates/solar-encryption-secret.yaml
+++ b/templates/solar-encryption-secret.yaml
@@ -1,3 +1,7 @@
+{{- if and (not .Values.textualEncryptionSecret) (not .Values.textualEncryptionSecretExistingSecret) }}
+    {{- fail "Either textualEncryptionSecret or textualEncryptionSecretExistingSecret must be set" }}
+{{- end }}
+{{- if .Values.textualEncryptionSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,7 +9,8 @@ metadata:
   labels:
     {{- include "textual.allLabels" (list $ (dict "secret-type" "textual-encryption-secret")) | nindent 4 }}
   annotations:
-    {{- include "textual.allAnnotations" (list $) | nindent 4 }}  
+    {{- include "textual.allAnnotations" (list $) | nindent 4 }}
 type: Opaque
 data:
   secret: {{ .Values.textualEncryptionSecret | b64enc }}
+{{- end }}

--- a/templates/solar-license-secret.yaml
+++ b/templates/solar-license-secret.yaml
@@ -1,3 +1,7 @@
+{{- if and (not .Values.solarLicense) (not .Values.solarLicenseExistingSecret) }}
+    {{- fail "Either solarLicense or solarLicenseExistingSecret must be set" }}
+{{- end }}
+{{- if .Values.solarLicense }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +13,4 @@ metadata:
 type: Opaque
 data:
   secret: {{ .Values.solarLicense | b64enc }}
+{{- end }}

--- a/templates/solar-worker-deployment.yaml
+++ b/templates/solar-worker-deployment.yaml
@@ -62,13 +62,11 @@ spec:
             - name: SOLAR_LICENSE
               valueFrom:
                 secretKeyRef:
-                  name: solar-license-secret
-                  key: secret
+                  {{- include "textual.licenseSecretRef" . | nindent 18 }}
             - name: SOLAR_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: textual-encryption-secret
-                  key: secret
+                  {{- include "textual.encryptionSecretRef" . | nindent 18 }}
             - name: SOLAR_DB_DATABASE
               value: {{ .Values.textualDatabase.dbName }}
             - name: SOLAR_DB_USERNAME
@@ -107,23 +105,21 @@ spec:
             - name: ENABLE_LOG_COLLECTION
               value: {{ .Values.enableLogCollection | quote }}
             {{- end }}
-            {{- if .Values.azureDocIntelligenceKey }}
+            {{- if or .Values.azureDocIntelligenceKey .Values.azureDocIntelligenceKeyExistingSecret }}
             - name: SOLAR_AZURE_DOC_INTELLIGENCE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: azure-document-intelligence-key-secret
-                  key: secret
+                  {{- include "textual.azureDocIntelligenceKeySecretRef" . | nindent 18 }}
             {{- end }}
             {{- if .Values.azureDocIntelligenceEndpoint }}
             - name: SOLAR_AZURE_DOC_INTELLIGENCE_ENDPOINT
               value: {{ .Values.azureDocIntelligenceEndpoint }}
             {{- end }}
-            {{- if .Values.openAiApiKey }}
+            {{- if or .Values.openAiApiKey .Values.openAiApiKeyExistingSecret }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: openai-api-key
-                  key: secret
+                  {{- include "textual.openAiApiKeySecretRef" . | nindent 18 }}
             {{- end }}
             {{- if (.Values.textual_worker).env}}
             {{- range $key, $value := .Values.textual_worker.env }}

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,13 @@ environmentName: <company-name>
 textualVersion: "<version-number>"
 
 solarLicense: <license>
+# Option B: reference an existing K8s Secret
+# solarLicenseExistingSecret: <secret-name>
+# solarLicenseExistingSecretKey: secret  # key within the secret, defaults to "secret"
 textualEncryptionSecret: <encryption-key>
+# Option B: reference an existing K8s Secret
+# textualEncryptionSecretExistingSecret: <secret-name>
+# textualEncryptionSecretExistingSecretKey: secret  # key within the secret, defaults to "secret"
 asr:
   create: false
 
@@ -132,6 +138,11 @@ solarStatisticsSeed: <any-integer>
 
 # Optional, required when using using llm synthesis
 openAiApiKey: <open-ai-api-key>
+# openAiApiKeyExistingSecret: <secret-name>
+# openAiApiKeyExistingSecretKey: secret
+
+# chatApiKeyExistingSecret: <secret-name>
+# chatApiKeyExistingSecretKey: secret
 
 # AI Chat Config
 #chatLlmProvider: gemini
@@ -141,12 +152,16 @@ openAiApiKey: <open-ai-api-key>
 
 # OCR Credentials
 #azureDocIntelligenceKey: <key>
+#azureDocIntelligenceKeyExistingSecret: <secret-name>
+#azureDocIntelligenceKeyExistingSecretKey: secret
 #azureDocIntelligenceEndpoint: <enndpoint-url>
 
 # Google SSO Config
 # -----------------
 #googleClientId: <client-id>
 #googleClientSecret: <client-secret>
+#googleClientSecretExistingSecret: <secret-name>
+#googleClientSecretExistingSecretKey: secret
 # -- Optional --
 # Must be set to import groups
 #googleGroupFilterRegex: <regex-pattern-for-groups>
@@ -165,12 +180,16 @@ openAiApiKey: <open-ai-api-key>
 # -----------------
 #githubClientId: <client-id>
 #githubClientSecret: <client-secret>
+#githubClientSecretExistingSecret: <secret-name>
+#githubClientSecretExistingSecretKey: secret
 
 # Azure SSO Config
 # -----------------
 #azureClientId: <client-id>
 #azureTenantId: <tenant-id>
 #azureClientSecret: <client-secret>
+#azureClientSecretExistingSecret: <secret-name>
+#azureClientSecretExistingSecretKey: secret
 # -- Optional --
 # Must be set to import groups
 #azureGroupFilterRegex: <regex-pattern-for-groups>
@@ -179,6 +198,8 @@ openAiApiKey: <open-ai-api-key>
 # -----------------
 #keycloakClientId: <client-id>
 #keycloakClientSecret: <client-secret>
+#keycloakClientSecretExistingSecret: <secret-name>
+#keycloakClientSecretExistingSecretKey: secret
 #keycloakAuthority: <authority-url>
 # -- Optional --
 # Must be set to import groups


### PR DESCRIPTION
All secrets (license, encryption secret, OpenAI key, SSO client secrets, Azure Doc Intelligence key, chat API key) can now be sourced from a pre-existing K8s secret instead of being passed as inline values. Adds helper functions for each secret ref and documents options in README and values.yaml.

This can be tested via this project - https://github.com/Ken-Tonic/textual-setup-easy-kt - use the textual-with-more-secrets branch.