### PR TITLE
Add runtime analytics Helm secrets

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -104,6 +104,8 @@ The same pattern applies to all other sensitive values:
 |---|---|---|---|
 | `openAiApiKey` | `openAiApiKeyExistingSecret` | `openAiApiKeyExistingSecretKey` | `secret` |
 | `chatApiKey` | `chatApiKeyExistingSecret` | `chatApiKeyExistingSecretKey` | `secret` |
+| `amplitudeApiKey` | `amplitudeApiKeyExistingSecret` | `amplitudeApiKeyExistingSecretKey` | `secret` |
+| `analyticBackendSalt` | `analyticBackendSaltExistingSecret` | `analyticBackendSaltExistingSecretKey` | `secret` |
 | `azureDocIntelligenceKey` | `azureDocIntelligenceKeyExistingSecret` | `azureDocIntelligenceKeyExistingSecretKey` | `secret` |
 | `googleClientSecret` | `googleClientSecretExistingSecret` | `googleClientSecretExistingSecretKey` | `secret` |
 | `githubClientSecret` | `githubClientSecretExistingSecret` | `githubClientSecretExistingSecretKey` | `secret` |
@@ -111,6 +113,12 @@ The same pattern applies to all other sensitive values:
 | `keycloakClientSecret` | `keycloakClientSecretExistingSecret` | `keycloakClientSecretExistingSecretKey` | `secret` |
 
 When using an `ExistingSecret`, the chart will not create a Kubernetes secret for that value — it will reference the named secret directly. For optional values, if neither the direct value nor `ExistingSecret` is set, the corresponding environment variable is simply omitted.
+
+### Analytics
+
+Release images do not include Amplitude credentials. To enable analytics, provide `amplitudeApiKey` and `analyticBackendSalt`, or reference existing Kubernetes Secrets with `amplitudeApiKeyExistingSecret` and `analyticBackendSaltExistingSecret`.
+
+The chart injects these values into the API server and worker pods as `AMPLITUDE_API_KEY` and `ANALYTIC_BACKEND_SALT`. ML, Roberta, ASR, and other service pods do not receive them.
 
 
 ### Authorization to access Tonic application Docker images

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -279,6 +279,37 @@ name: {{ .Values.azureDocIntelligenceKeyExistingSecret | default "azure-document
 key: {{ .Values.azureDocIntelligenceKeyExistingSecretKey | default "secret" }}
 {{- end }}
 
+{{- define "textual.amplitudeApiKeySecretRef" -}}
+name: {{ .Values.amplitudeApiKeyExistingSecret | default "amplitude-api-key" }}
+key: {{ .Values.amplitudeApiKeyExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{- define "textual.analyticBackendSaltSecretRef" -}}
+name: {{ .Values.analyticBackendSaltExistingSecret | default "analytic-backend-salt" }}
+key: {{ .Values.analyticBackendSaltExistingSecretKey | default "secret" }}
+{{- end }}
+
+{{/*
+Analytics runtime env vars for API and worker pods.
+
+These secrets are intentionally runtime-only so release images do not contain
+Amplitude credentials in Dockerfile ENV, image config, or image history.
+*/}}
+{{- define "textual.analyticsEnv" -}}
+{{- if or .Values.amplitudeApiKey .Values.amplitudeApiKeyExistingSecret }}
+- name: AMPLITUDE_API_KEY
+  valueFrom:
+    secretKeyRef:
+      {{- include "textual.amplitudeApiKeySecretRef" . | nindent 6 }}
+{{- end }}
+{{- if or .Values.analyticBackendSalt .Values.analyticBackendSaltExistingSecret }}
+- name: ANALYTIC_BACKEND_SALT
+  valueFrom:
+    secretKeyRef:
+      {{- include "textual.analyticBackendSaltSecretRef" . | nindent 6 }}
+{{- end }}
+{{- end }}
+
 {{/*
 LLM provider credentials and feature config env vars.
 

--- a/templates/amplitude-api-key-secret.yaml
+++ b/templates/amplitude-api-key-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.amplitudeApiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: amplitude-api-key
+  labels:
+    {{- include "textual.allLabels" (list $ (dict "secret-type" "amplitude-api-key")) | nindent 4 }}
+  annotations:
+    {{- include "textual.allAnnotations" (list $) | nindent 4 }}
+type: Opaque
+data:
+  secret: {{ .Values.amplitudeApiKey | b64enc }}
+{{- end }}

--- a/templates/analytic-backend-salt-secret.yaml
+++ b/templates/analytic-backend-salt-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.analyticBackendSalt }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: analytic-backend-salt
+  labels:
+    {{- include "textual.allLabels" (list $ (dict "secret-type" "analytic-backend-salt")) | nindent 4 }}
+  annotations:
+    {{- include "textual.allAnnotations" (list $) | nindent 4 }}
+type: Opaque
+data:
+  secret: {{ .Values.analyticBackendSalt | b64enc }}
+{{- end }}

--- a/templates/solar-api-server-deployment.yaml
+++ b/templates/solar-api-server-deployment.yaml
@@ -67,6 +67,7 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- end }}
+          {{- include "textual.analyticsEnv" . | nindent 10 }}
           - name: SOLAR_SECRET
             valueFrom:
               secretKeyRef:

--- a/templates/solar-worker-deployment.yaml
+++ b/templates/solar-worker-deployment.yaml
@@ -119,6 +119,7 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+            {{- include "textual.analyticsEnv" . | nindent 12 }}
             {{- include "textual.customCa.env" . | nindent 12 }}
           {{- if (.Values.textual_worker).image }}
           image: {{ .Values.textual_worker.image }}:{{ .Values.textualVersion }}

--- a/values.yaml
+++ b/values.yaml
@@ -29,6 +29,15 @@ textualDatabase:
   ## Optional, if you want to customize the schema name used (defaults to "public")
   # schema: public
 
+# Optional analytics runtime settings. Release images do not contain analytics
+# secrets; set these values, or reference existing Kubernetes Secrets, when the
+# deployment should send Amplitude events.
+amplitudeApiKey: ""
+# amplitudeApiKeyExistingSecret: <secret-name>
+# amplitudeApiKeyExistingSecretKey: secret
+analyticBackendSalt: ""
+# analyticBackendSaltExistingSecret: <secret-name>
+# analyticBackendSaltExistingSecretKey: secret
 
 # Optional Labels to add to all resources - if there is a conflict we use allLabels
 # allLabels: {


### PR DESCRIPTION
## Summary
- add first-class Helm values for runtime Amplitude API key and analytics backend salt
- support both chart-created secrets and existing Kubernetes Secrets
- inject analytics env only into API and worker pods

## Verification
- helm lint /tmp/textual_helm_charts -f /tmp/textual_helm_charts/values.yaml
- helm template textual /tmp/textual_helm_charts -f /tmp/textual_helm_charts/values.yaml --set amplitudeApiKey=test-amplitude --set analyticBackendSalt=test-salt
- helm template textual /tmp/textual_helm_charts -f /tmp/textual_helm_charts/values.yaml --set amplitudeApiKeyExistingSecret=analytics-secret --set amplitudeApiKeyExistingSecretKey=amplitude --set analyticBackendSaltExistingSecret=analytics-secret --set analyticBackendSaltExistingSecretKey=salt

Related Solar PR: https://github.com/TonicAI/solar/pull/3023